### PR TITLE
Commenting out print_uinfo('FINISHED',$uinfo), since it's not worthwhile...

### DIFF
--- a/timeout
+++ b/timeout
@@ -179,7 +179,7 @@ while ($status eq 'wait'){
 	}
 }
 
-print_uinfo('FINISHED',$uinfo);
+#print_uinfo('FINISHED',$uinfo);
 exit $box_status;
 
 #-----------------------------------------------


### PR DESCRIPTION
... to print something to STDOUT if the processes terminated fine without exceeding limits.
