### PR TITLE
print the warning message of unexpected behavior to STDERR instead of STDOUT

### DIFF
--- a/timeout
+++ b/timeout
@@ -175,7 +175,7 @@ while ($status eq 'wait'){
 	}elsif ($arrived == -1){
 		# Something happened!
 		print_uinfo('INTERNAL',$uinfo);
-		print "timeout: WARNING: Wait($blackbox_pid) failed: $child_errno\n";
+		print STDERR "timeout: WARNING: Wait($blackbox_pid) failed: $child_errno\n";
 		exit 0;
 	}else{
 		# Check if limits are exhausted (they should be updated by signal handler).


### PR DESCRIPTION
It is better to print this warning message in STDERR instead of STDOUT
