### PR TITLE
fixing typo in the memory limiting example

### DIFF
--- a/README
+++ b/README
@@ -113,7 +113,7 @@ Basic time limiting:
     Outputs:
     TIMEOUT 2.04 CPU
 
-Basic memory limiting (100M of virtual memory):
+Basic memory limiting (1000M of virtual memory):
 
     ./timeout -m 1000000 perl -e 'while ($i<100000000) {$a->{$i} = $i++;}'
     Outputs:


### PR DESCRIPTION
it seems `-m 1000000` is equal to 1000M of virtual memory, instead of 100M